### PR TITLE
Add streams & Fix bug: Stream reusing fails unit test

### DIFF
--- a/src/main/java/duke/logic/tasks/TaskList.java
+++ b/src/main/java/duke/logic/tasks/TaskList.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * Represents a list of tasks.
@@ -84,9 +83,8 @@ public class TaskList {
      * @return A list of resulting tasks.
      */
     public List<Task> find(String[] keywords) {
-        Stream<String> searchWords = Arrays.stream(keywords);
         return list.stream()
-                .filter(task -> searchWords.anyMatch(task::containsKeyword))
+                .filter(task -> Arrays.stream(keywords).anyMatch(task::containsKeyword))
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
In `find` method of TaskList, creating just one stream and use it inside multiple filter operations will throw an error because the stream has already been operated upon once already. Fix this by reinitializing the stream each time we search a task for the keywords.